### PR TITLE
fix(ci): install local package before mkdocs gh-deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,7 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
 
+      - name: Install local package (plugins)
+        run: uv pip install -e .
+
       - run: uv run mkdocs gh-deploy --force


### PR DESCRIPTION
Add `uv pip install -e .` step to ensure local MkDocs plugins are registered before building/deploying the site.

This fixes the CI workflow failing with `Plugin 'optimize' not found` when the project contains local MkDocs plugins defined in the workspace.