### PR TITLE
feat: add Umami analytics tracking

### DIFF
--- a/overrides/partials/integrations/analytics.html
+++ b/overrides/partials/integrations/analytics.html
@@ -1,0 +1,2 @@
+<!-- Umami Analytics -->
+<script defer src="https://cloud.umami.is/script.js" data-website-id="81c66ab1-313b-475e-a485-160fa0adfa05"></script>


### PR DESCRIPTION
Add privacy-friendly Umami analytics to the site via MkDocs Material's `partials/integrations/analytics.html` hook.

- No cookies, no tracking fingerprint, GDPR compliant
- Uses Umami cloud (free tier: 10k events/month)
- Script is `defer` so it doesn't block page rendering