### PR TITLE
fix(plugins): escape HTML special chars in excerpt description

### DIFF
--- a/plugins/excerpt_description.py
+++ b/plugins/excerpt_description.py
@@ -8,6 +8,7 @@ The plugin runs on on_page_markdown with priority -60, which is after the blog
 plugin's on_page_markdown (priority -50) so that page.excerpt is already created.
 """
 
+import html
 import re
 from mkdocs.plugins import BasePlugin, event_priority
 
@@ -101,6 +102,6 @@ class ExcerptDescriptionPlugin(BasePlugin):
             description = description[:max_length].rsplit(" ", 1)[0]
             description += "..."
 
-        # Set the description
+        # Set the description (escape HTML special chars for safe meta tag output)
         if description:
-            page.meta["description"] = description
+            page.meta["description"] = html.escape(description, quote=True)

--- a/plugins/json_ld.py
+++ b/plugins/json_ld.py
@@ -7,6 +7,7 @@ Runs on on_post_page so that all metadata (including description from
 excerpt_description plugin) is already available.
 """
 
+import html
 import json
 import os
 from datetime import datetime, timezone
@@ -43,7 +44,8 @@ class JsonLdPlugin(BasePlugin):
         post_url = f"{site_url.rstrip('/')}/{page.url}"
 
         # Get description from meta (set by excerpt_description plugin)
-        description = page.meta.get("description", "")
+        # Unescape HTML entities since json.dumps handles its own escaping
+        description = html.unescape(page.meta.get("description", ""))
 
         # Get date from post config - blog plugin stores date as a DateDict
         # with "created" key (and optionally "updated", etc.)


### PR DESCRIPTION
## Problem

The `excerpt_description` plugin was injecting raw text into meta tags without escaping HTML special characters. When a post excerpt contained quotes or other special characters, the generated HTML was invalid.

### Before
```html
<meta name="description" content="This is a "quoted" excerpt">
<meta property="og:description" content="This is a "quoted" excerpt">
<meta property="twitter:description" content="This is a "quoted" excerpt">
```

### After
```html
<meta name="description" content="This is a &quot;quoted&quot; excerpt">
<meta property="og:description" content="This is a &quot;quoted&quot; excerpt">
<meta property="twitter:description" content="This is a &quot;quoted&quot; excerpt">
```

## Changes

- **excerpt_description.py**: Added `html.escape()` to all three meta description values (name, og, twitter)
- **json_ld.py**: Added `html.unescape()` before `json.dumps()` so JSON-LD gets proper raw text (json.dumps handles its own JSON escaping)

## Testing

- Built site locally with `make build`
- Verified HTML meta tags use `&quot;` for quotes
- Verified JSON-LD uses proper `"` quotes (valid JSON)
- Confirmed no regressions on other posts