### PR TITLE
fix: suppress MkDocs absolute link warnings

### DIFF
--- a/docs/posts/2026-01-24-lookback.md
+++ b/docs/posts/2026-01-24-lookback.md
@@ -21,7 +21,7 @@ Happy 2026 data delvers! As we enter a new year I wanted to take some time to re
 
 ## Datadelver Blog
 
-2025 was my most active blogging year yet. I published a total of [14 blog posts](/archive/2025.html) including the start of my [Modern ML Microservices Series](/tags.html#tag:modern-ml-microservices), which received a lot of positive feedback. I'm also particularly pleased with [Delve 17: Data Science, An Industry Perspective](2025-10-07-data-science-industry-perspective.md), which had some of the best LinkedIn engagement with a single blog post I've ever had. I began 2025 with a soft goal of publishing one blog post per month which I'm happy to say I stuck to. Overall, I'd say I enjoyed the variety in the types of posts I made throughout the year and it's something I hope to continue into 2026!
+2025 was my most active blogging year yet. I published a total of [14 blog posts](../archive/2025.md) including the start of my [Modern ML Microservices Series](../tags.md#tag:modern-ml-microservices), which received a lot of positive feedback. I'm also particularly pleased with [Delve 17: Data Science, An Industry Perspective](2025-10-07-data-science-industry-perspective.md), which had some of the best LinkedIn engagement with a single blog post I've ever had. I began 2025 with a soft goal of publishing one blog post per month which I'm happy to say I stuck to. Overall, I'd say I enjoyed the variety in the types of posts I made throughout the year and it's something I hope to continue into 2026!
 
 ## Career
 


### PR DESCRIPTION
## Changes

- Converted absolute links to relative links in the 2025 lookback post

## Why

MkDocs warns about absolute links in doc files. Using relative `.md` paths suppresses these warnings since MkDocs automatically resolves `.md` links to `.html` in the output.

## Notes

- One harmless INFO message remains about the tags anchor (false positive — the anchor is generated by the tags plugin at build time, not present in the source `.md` file).
- Both links resolve correctly in the built site output.
