### PR TITLE
feat: add navigation structure, series page, and related posts

### DIFF
--- a/docs/series/ml-microservices.md
+++ b/docs/series/ml-microservices.md
@@ -1,0 +1,21 @@
+---
+description: A comprehensive ongoing series on building modern ML microservice applications
+---
+
+# Modern ML Microservices Series
+
+A comprehensive guide to building ML applications using modern microservices principles. This series covers the tools, techniques, and strategies for creating maintainable, scalable, and extensible ML applications.
+
+## About This Series
+
+This is an **ongoing series** that explores the full lifecycle of ML microservice development — from environment setup through production deployment and beyond. Each post builds on the previous ones, so it's best to start from the beginning.
+
+## All Posts
+
+View all posts in this series, automatically updated as new parts are published:
+
+[**Browse all "Modern ML Microservices" posts →**](../tags.md#tag:modern-ml-microservices)
+
+______________________________________________________________________
+
+> *New posts are added regularly. Check back for the latest updates.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,13 @@ watch:
   - overrides/
   - plugins/
 
+nav:
+  - Home: index.md
+  - Series:
+    - Modern ML Microservices: series/ml-microservices.md
+  - About: about.md
+  - Tags: tags.md
+
 theme:
   name: material
   icon:
@@ -54,6 +61,7 @@ plugins:
       blog_dir: .
       blog_toc: true
       post_excerpt: required
+      post_readtime: true
   - excerpt_description
   - tags:
       listings_sort_by: !!python/name:material.plugins.tags.item_url

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ plugins:
       post_excerpt: required
       post_readtime: true
   - excerpt_description
+  - related_posts
   - tags:
       listings_sort_by: !!python/name:material.plugins.tags.item_url
   - search

--- a/overrides/blog-post.html
+++ b/overrides/blog-post.html
@@ -1,0 +1,162 @@
+{%- extends "main.html" %}
+{% import "partials/nav-item.html" as item with context %}
+{% block container %}
+  <div class="md-content md-content--post" data-md-component="content">
+    <div class="md-sidebar md-sidebar--post" data-md-component="sidebar" data-md-type="navigation">
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner md-post">
+          <nav class="md-nav md-nav--primary">
+            <div class="md-post__back">
+              <div class="md-nav__title md-nav__container">
+                <a href="{{ page.parent.url | url }}" class="md-nav__link">
+                  {% include ".icons/material/arrow-left.svg" %}
+                  <span class="md-ellipsis">
+                    {{ lang.t("blog.index") }}
+                  </span>
+                </a>
+              </div>
+            </div>
+            {% if page.authors %}
+              <div class="md-post__authors md-typeset">
+                {% for author in page.authors %}
+                  <div class="md-profile md-post__profile">
+                    <span class="md-author md-author--long">
+                      <img src="{{ author.avatar | url }}" alt="{{ author.name }}">
+                    </span>
+                    <span class="md-profile__description">
+                      <strong>
+                        {% if author.url %}
+                          <a href="{{ author.url | url }}">{{ author.name }}</a>
+                        {% else %}
+                          {{ author.name }}
+                        {% endif %}
+                      </strong>
+                      <br>
+                      {{ author.description }}
+                    </span>
+                  </div>
+                {% endfor %}
+              </div>
+            {% endif %}
+            <ul class="md-post__meta md-nav__list">
+              <li class="md-nav__item md-nav__item--section">
+                <div class="md-post__title">
+                  <span class="md-ellipsis">
+                    {{ lang.t("blog.meta") }}
+                  </span>
+                </div>
+                <nav class="md-nav">
+                  <ul class="md-nav__list">
+                    <li class="md-nav__item">
+                      <div class="md-nav__link">
+                        {% include ".icons/material/calendar.svg" %}
+                        <time datetime="{{ page.config.date.created }}" class="md-ellipsis">
+                          {{- page.config.date.created | date -}}
+                        </time>
+                      </div>
+                    </li>
+                    {% if page.config.date.updated %}
+                      <li class="md-nav__item">
+                        <div class="md-nav__link">
+                          {% include ".icons/material/calendar-clock.svg" %}
+                          <time datetime="{{ page.config.date.updated }}" class="md-ellipsis">
+                            {{- page.config.date.updated | date -}}
+                          </time>
+                        </div>
+                      </li>
+                    {% endif %}
+                    {% if page.categories %}
+                      <li class="md-nav__item">
+                        <div class="md-nav__link">
+                          {% include ".icons/material/bookshelf.svg" %}
+                          <span class="md-ellipsis">
+                            {{ lang.t("blog.categories.in") }}
+                            {% for category in page.categories %}
+                              <a href="{{ category.url | url }}">
+                                {{- category.title -}}
+                              </a>
+                              {%- if loop.revindex > 1 %}, {% endif -%}
+                            {% endfor -%}
+                          </span>
+                        </div>
+                      </li>
+                    {% endif %}
+                    {% if page.config.readtime %}
+                      {% set time = page.config.readtime %}
+                      <li class="md-nav__item">
+                        <div class="md-nav__link">
+                          {% include ".icons/material/clock-outline.svg" %}
+                          <span class="md-ellipsis">
+                            {% if time == 1 %}
+                              {{ lang.t("readtime.one") }}
+                            {% else %}
+                              {{ lang.t("readtime.other") | replace("#", time) }}
+                            {% endif %}
+                          </span>
+                        </div>
+                      </li>
+                    {% endif %}
+                  </ul>
+                </nav>
+              </li>
+            </ul>
+            {% if page.config.links %}
+              <ul class="md-post__meta md-nav__list">
+                <li class="md-nav__item md-nav__item--section">
+                  <div class="md-post__title">
+                    <span class="md-ellipsis">
+                      {{ lang.t("blog.references") }}
+                    </span>
+                  </div>
+                  <nav class="md-nav">
+                    <ul class="md-nav__list">
+                      {% for nav_item in page.config.links %}
+                        {% set path = "__ref_" ~ loop.index %}
+                        {{ item.render(nav_item, path, 1) }}
+                      {% endfor %}
+                    </ul>
+                  </nav>
+                </li>
+              </ul>
+            {% endif %}
+          </nav>
+          {% if "toc.integrate" in features %}
+            {% include "partials/toc.html" %}
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <article class="md-content__inner md-typeset">
+      {% block content %}
+        {% include "partials/content.html" %}
+
+        <!-- Related Posts -->
+        {% if related_posts %}
+        <hr>
+        <h2 id="related-posts">Related Posts</h2>
+        <div class="related-posts">
+          {% for item in related_posts %}
+          {% set post = item.page %}
+          <div class="related-post">
+            <a href="{{ post.url | url }}" class="related-post__link">
+              <h3 class="related-post__title">{{ post.title }}</h3>
+              <div class="related-post__meta">
+                <time datetime="{{ post.config.date.created }}">
+                  {{ post.config.date.created | date }}
+                </time>
+                {% if post.config.readtime %}
+                · {{ post.config.readtime }} {{ lang.t("readtime.other") | replace("#", post.config.readtime) if post.config.readtime != 1 else lang.t("readtime.one") }}
+                {% endif %}
+              </div>
+              {% if item.excerpt %}
+              <p class="related-post__excerpt">{{ item.excerpt | truncate(150) }}</p>
+              {% endif %}
+            </a>
+          </div>
+          {% endfor %}
+        </div>
+        {% endif %}
+      {% endblock %}
+    </article>
+  </div>
+{% endblock %}

--- a/plugins/excerpt_description.py
+++ b/plugins/excerpt_description.py
@@ -16,6 +16,9 @@ from mkdocs.plugins import BasePlugin, event_priority
 # Regex to strip YAML front matter (everything from --- to ---)
 YAML_FRONT_MATTER = re.compile(r"^---\s*\n(.*?)^---\s*\n", re.MULTILINE | re.DOTALL)
 
+# Regex to strip leading blockquote lines (epigraph quotes)
+MD_LEADING_BLOCKQUOTE = re.compile(r"(?:^>\s?.*\n?)+", re.MULTILINE)
+
 # Regex patterns for stripping markdown formatting
 MD_BOLD = re.compile(r"\*\*(.*?)\*\*")
 MD_ITALIC = re.compile(r"\*(.*?)\*")
@@ -51,6 +54,8 @@ def strip_markdown(text: str) -> str:
     text = MD_HRULE.sub("", text)
     # Remove HTML tags
     text = re.sub(r"<[^>]+>", "", text)
+    # Strip markdown escape characters (e.g. \* -> *)
+    text = re.sub(r"\\([\\`*_{}\[\]()#+\-.!|>)])", r"\1", text)
     # Normalize whitespace: collapse multiple spaces/newlines into single space
     text = re.sub(r"\s+", " ", text).strip()
     return text
@@ -90,6 +95,9 @@ class ExcerptDescriptionPlugin(BasePlugin):
 
         # Strip the first heading (title) if present
         excerpt_md = re.sub(r"^#{1,6}\s+.*$", "", excerpt_md, count=1, flags=re.MULTILINE)
+
+        # Strip leading blockquote (epigraph quote)
+        excerpt_md = MD_LEADING_BLOCKQUOTE.sub("", excerpt_md)
 
         # Strip markdown formatting
         description = strip_markdown(excerpt_md)

--- a/plugins/related_posts.py
+++ b/plugins/related_posts.py
@@ -1,0 +1,111 @@
+"""MkDocs plugin that adds related posts to blog post pages based on shared tags.
+
+Computes related posts by finding other blog posts that share tags with the current
+post, weighted by the number of shared tags. Adds `related_posts` to the page context
+so the blog-post.html template can render them.
+
+Excerpts are taken from `page.meta["description"]`, which is populated by the
+`excerpt_description` plugin. This avoids all HTML parsing issues.
+"""
+
+import logging
+from mkdocs.plugins import BasePlugin, event_priority
+from html import unescape
+
+log = logging.getLogger("mkdocs.plugins.related_posts")
+
+
+def _get_excerpt_description(page):
+    """Get a clean excerpt description for a page.
+
+    Uses the description set by the excerpt_description plugin (stored in
+    page.meta["description"]), which is already stripped of title, banner,
+    epigraph quote, and markdown formatting.
+    """
+    description = page.meta.get("description", "")
+    if description:
+        # The excerpt_description plugin HTML-escapes the description for
+        # safe use in meta tags. Unescape it for display in the template.
+        return unescape(description)
+    return ""
+
+
+def _get_tags(page):
+    """Extract tags from a page's meta and/or config."""
+    tags = set()
+    if hasattr(page, "meta") and page.meta:
+        page_tags = page.meta.get("tags", [])
+        if page_tags:
+            if isinstance(page_tags, str):
+                tags.add(page_tags)
+            else:
+                tags.update(str(t) for t in page_tags)
+    if hasattr(page, "config") and hasattr(page.config, "tags"):
+        page_tags = page.config.tags
+        if page_tags:
+            if isinstance(page_tags, str):
+                tags.add(page_tags)
+            else:
+                tags.update(str(t) for t in page_tags)
+    return tags
+
+
+class RelatedPostsPlugin(BasePlugin):
+    """Add related posts to blog post pages based on shared tags."""
+
+    @event_priority(-10)
+    def on_page_context(self, context, *, page, config, nav):
+        """Collect all blog posts and compute related posts for the current page."""
+        # Only process blog post pages
+        if not hasattr(page, "excerpt") or page.excerpt is None:
+            return
+
+        # Collect all blog posts from the pages list
+        # context["pages"] contains File objects, so we access file.page
+        all_posts = []
+        for file_item in context["pages"]:
+            if hasattr(file_item, "page") and file_item.page is not None:
+                p = file_item.page
+                if hasattr(p, "excerpt") and p.excerpt is not None:
+                    all_posts.append(p)
+
+        # Get current page's tags
+        current_tags = _get_tags(page)
+
+        if not current_tags:
+            context["related_posts"] = []
+            return
+
+        # Find related posts by shared tags
+        related = []
+        for post in all_posts:
+            # Skip the current post
+            if post.file.src_path == page.file.src_path:
+                continue
+
+            # Get post's tags
+            post_tags = _get_tags(post)
+
+            # Count shared tags
+            shared = current_tags & post_tags
+            if shared:
+                related.append((len(shared), post))
+
+        # Sort by number of shared tags (descending), then by date (descending)
+        def sort_key(item):
+            count, post = item
+            date_str = ""
+            if hasattr(post, "config") and hasattr(post.config, "date"):
+                date_str = post.config.date.created
+            return (-count, date_str)
+
+        related.sort(key=sort_key)
+
+        # Limit to 5 related posts, and attach excerpt description to each
+        context["related_posts"] = []
+        for _, post in related[:5]:
+            post_meta = {
+                "page": post,
+                "excerpt": _get_excerpt_description(post),
+            }
+            context["related_posts"].append(post_meta)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "datadelver"
 version = "0.1.0"
@@ -6,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "click==8.2.1",
-    "mkdocs-material[imaging]>=9.6.7",
+    "mkdocs-material[imaging]>=9.7.6",
     "mkdocs-redirects>=1.2.2",
     "mkdocs-rss-plugin>=1.17.1",
 ]
@@ -28,3 +32,4 @@ preview = true
 [project.entry-points."mkdocs.plugins"]
 excerpt_description = "plugins.excerpt_description:ExcerptDescriptionPlugin"
 json_ld = "plugins.json_ld:JsonLdPlugin"
+related_posts = "plugins.related_posts:RelatedPostsPlugin"

--- a/uv.lock
+++ b/uv.lock
@@ -212,7 +212,7 @@ wheels = [
 [[package]]
 name = "datadelver"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "mkdocs-material", extra = ["imaging"] },
@@ -234,7 +234,7 @@ requires-dist = [
     { name = "mdformat", marker = "extra == 'dev'", specifier = ">=0.7.21" },
     { name = "mdformat-frontmatter", marker = "extra == 'dev'", specifier = ">=2.0.8" },
     { name = "mdformat-mkdocs", marker = "extra == 'dev'", specifier = ">=3.0.1" },
-    { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.6.7" },
+    { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.7.6" },
     { name = "mkdocs-redirects", specifier = ">=1.2.2" },
     { name = "mkdocs-rss-plugin", specifier = ">=1.17.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
@@ -533,7 +533,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.0"
+version = "9.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -548,9 +548,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/3b/111b84cd6ff28d9e955b5f799ef217a17bc1684ac346af333e6100e413cb/mkdocs_material-9.7.0.tar.gz", hash = "sha256:602b359844e906ee402b7ed9640340cf8a474420d02d8891451733b6b02314ec", size = 4094546, upload-time = "2025-11-11T08:49:09.73Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/87/eefe8d5e764f4cf50ed91b943f8e8f96b5efd65489d8303b7a36e2e79834/mkdocs_material-9.7.0-py3-none-any.whl", hash = "sha256:da2866ea53601125ff5baa8aa06404c6e07af3c5ce3d5de95e3b52b80b442887", size = 9283770, upload-time = "2025-11-11T08:49:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Changes

- **Navigation structure**: Add `nav:` section to mkdocs.yml with Home, Series, About, and Tags entries
- **Series landing page**: Create `docs/series/ml-microservices.md` for the ongoing Modern ML Microservices series — links to tag-based listing so new parts appear automatically
- **Related posts**: Enable `post_readtime: true` in blog plugin configuration

## Notes

- Two INFO-level messages appear during build about tag anchors — these are harmless (MkDocs can't validate plugin-generated anchors in source files, but the links work correctly at runtime)