### PR TITLE
fix: remove duplicate reading time in related posts excerpts

### DIFF
--- a/overrides/blog-post.html
+++ b/overrides/blog-post.html
@@ -145,7 +145,7 @@
                   {{ post.config.date.created | date }}
                 </time>
                 {% if post.config.readtime %}
-                · {{ post.config.readtime }} {{ lang.t("readtime.other") | replace("#", post.config.readtime) if post.config.readtime != 1 else lang.t("readtime.one") }}
+                · {{ lang.t("readtime.other") | replace("#", post.config.readtime) if post.config.readtime != 1 else lang.t("readtime.one") }}
                 {% endif %}
               </div>
               {% if item.excerpt %}


### PR DESCRIPTION
## Problem

The related posts excerpts were displaying the reading time number twice (e.g. `5 5 min read` instead of `5 min read`).

## Root Cause

In `overrides/blog-post.html`, the reading time was output as both a raw value and within the translated string:

```jinja
· {{ post.config.readtime }} {{ lang.t("readtime.other") | replace("#", post.config.readtime) ...
```

The `lang.t("readtime.other")` string already contains a `#` placeholder that gets replaced with the number, so the standalone `{{ post.config.readtime }}` was redundant.

## Fix

Removed the duplicate `{{ post.config.readtime }}` so only the translated string is rendered.