### PR TITLE
feat: add custom 404 page with themed messaging

### DIFF
--- a/overrides/404.html
+++ b/overrides/404.html
@@ -1,0 +1,13 @@
+{% extends "main.html" %}
+{% block content %}
+  <h1>404 - Page Not Found</h1>
+  <p>
+    Looks like this page got lost in the data labyrinth. 
+    The content you're looking for doesn't exist or has been moved.
+  </p>
+  <p>
+    <a href="{{ config.site_url }}" class="md-button md-button--primary">
+      Back to the surface
+    </a>
+  </p>
+{% endblock %}


### PR DESCRIPTION
## Summary

Replace the default Material '404 - Not found' template with a custom 404 page that includes:

- A branded message referencing the 'data labyrinth' theme
- A styled button linking back to the homepage

## Changes

- Added `overrides/404.html` with custom Jinja2 template

## Preview

The new 404 page displays:
- **Title:** 404 - Page Not Found
- **Message:** "Looks like this page got lost in the data labyrinth. The content you're looking for doesn't exist or has been moved."
- **CTA:** "Back to the surface" button → homepage