### PR TITLE
UX enhancements: post navigation, progress bar, 404 button, related posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor
 site
 __pycache__
 *.egg-info
+scratch

--- a/docs/javascripts/extra.js
+++ b/docs/javascripts/extra.js
@@ -1,0 +1,12 @@
+/* Reading Progress Bar */
+(function() {
+  function updateProgress() {
+    const scrollTop = window.scrollY;
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    const progress = docHeight > 0 ? Math.min(100, (scrollTop / docHeight) * 100) : 0;
+    document.body.style.setProperty('--progress-width', progress + '%');
+  }
+
+  window.addEventListener("scroll", updateProgress, { passive: true });
+  updateProgress();
+})();

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -6,15 +6,10 @@ body::after {
     left: 0;
     height: 3px;
     width: var(--progress-width, 0%);
-    background: linear-gradient(90deg, #6c63ff, #ff6584);
+    background: linear-gradient(90deg, var(--md-primary-fg-color--light), var(--md-accent-fg-color));
     z-index: 300;
     transition: width 0.1s ease;
     pointer-events: none;
-}
-
-/* Dark theme */
-body[data-md-color-scheme="slate"]::after {
-    background: linear-gradient(90deg, #a78bfa, #f472b6);
 }
 
 /* Hide the original DOM element */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,27 @@
+/* Reading Progress Bar */
+body::after {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 3px;
+    width: var(--progress-width, 0%);
+    background: linear-gradient(90deg, #6c63ff, #ff6584);
+    z-index: 300;
+    transition: width 0.1s ease;
+    pointer-events: none;
+}
+
+/* Dark theme */
+body[data-md-color-scheme="slate"]::after {
+    background: linear-gradient(90deg, #a78bfa, #f472b6);
+}
+
+/* Hide the original DOM element */
+.md-progress {
+    display: none !important;
+}
+
 .md-typeset .admonition.claude,
 .md-typeset .admonition.claude-code,
 .md-typeset details.claude,

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -37,6 +37,111 @@ body[data-md-color-scheme="slate"]::after {
     border-color: #C15F3C;
 }
 
+/* Post Navigation */
+.md-post__navigation {
+    margin-top: 0.8rem;
+}
+
+.md-post__nav {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.8rem;
+}
+
+.md-post__nav--prev {
+    justify-self: start;
+}
+
+.md-post__nav--next {
+    justify-self: end;
+}
+
+.md-post__nav-link {
+    display: flex;
+    gap: 0.8rem;
+    padding: 1rem;
+    border-radius: 0.4rem;
+    border: 0.05rem solid var(--md-default-bg-color--lightest);
+    transition: border-color 0.25s, box-shadow 0.25s;
+    max-width: 100%;
+}
+
+.md-post__nav-link:hover {
+    border-color: var(--md-accent-fg-color);
+    box-shadow: 0 0.0625rem 0.125rem -0.0625rem var(--md-default-fg-color--lighter-03),
+                0 0.25rem 0.5rem -0.125rem var(--md-default-fg-color--lighter-06);
+}
+
+.md-post__nav-icon {
+    flex-shrink: 0;
+    width: 2.4rem;
+    height: 2.4rem;
+    color: var(--md-typeset-a-color);
+    transition: color 0.25s;
+}
+
+.md-post__nav-icon svg {
+    width: 2.4rem;
+    height: 2.4rem;
+    fill: currentColor;
+}
+
+.md-post__nav-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 0;
+}
+
+.md-post__nav--next .md-post__nav-label {
+    text-align: right;
+    align-items: flex-end;
+}
+
+.md-post__nav-direction {
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--md-default-fg-color--light);
+}
+
+.md-post__nav-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--md-typeset-a-color);
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    transition: color 0.25s;
+}
+
+.md-post__nav-link:hover .md-post__nav-title {
+    color: var(--md-accent-fg-color);
+}
+
+.md-post__nav-link:hover .md-post__nav-icon {
+    color: var(--md-accent-fg-color);
+}
+
+.md-post__nav-date {
+    font-size: 0.64rem;
+    color: var(--md-default-fg-color--light);
+}
+
+@media max-width: 76.1875em {
+    .md-post__nav {
+        grid-template-columns: 1fr;
+    }
+
+    .md-post__nav--prev,
+    .md-post__nav--next {
+        justify-self: stretch;
+    }
+}
+
 .md-typeset .admonition.claude>.admonition-title::before,
 .md-typeset .admonition.claude-code>.admonition-title::before,
 .md-typeset details.claude>summary::before,

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -71,7 +71,7 @@ body::after {
     flex-shrink: 0;
     width: 2.4rem;
     height: 2.4rem;
-    color: var(--md-typeset-a-color);
+    color: var(--md-default-fg-color--light);
     transition: color 0.25s;
 }
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -137,6 +137,23 @@ body::after {
     }
 }
 
+/* 404 page button – matches back-to-top button styling */
+.md-button.md-top-button {
+    background-color: var(--md-default-bg-color) !important;
+    border-radius: 1.6rem;
+    box-shadow: var(--md-shadow-z2);
+    color: var(--md-default-fg-color--light) !important;
+    font-size: 0.7rem;
+    padding: 0.4rem 0.8rem;
+    text-transform: uppercase;
+    transition: color 125ms, background-color 125ms;
+}
+
+.md-button.md-top-button:hover {
+    background-color: var(--md-accent-fg-color) !important;
+    color: var(--md-accent-bg-color) !important;
+}
+
 .md-typeset .admonition.claude>.admonition-title::before,
 .md-typeset .admonition.claude-code>.admonition-title::before,
 .md-typeset details.claude>summary::before,

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -137,6 +137,85 @@ body::after {
     }
 }
 
+/* Related Posts */
+.md-post__related {
+    margin: 3.2rem 0 0;
+}
+
+.md-post__related-heading {
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--md-default-fg-color--light);
+    margin: 0 0 1rem;
+}
+
+.md-post__related-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+    gap: 1rem;
+}
+
+.md-post__related-card {
+    border-radius: 0.4rem;
+    border: 0.05rem solid var(--md-default-bg-color--lightest);
+    transition: border-color 0.25s, box-shadow 0.25s;
+}
+
+.md-post__related-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1rem;
+    color: inherit;
+    text-decoration: none;
+}
+
+.md-post__related-card:hover {
+    border-color: var(--md-accent-fg-color);
+    box-shadow: 0 0.0625rem 0.125rem -0.0625rem var(--md-default-fg-color--lighter-03),
+                0 0.25rem 0.5rem -0.125rem var(--md-default-fg-color--lighter-06);
+}
+
+.md-post__related-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--md-typeset-a-color);
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    transition: color 0.25s;
+}
+
+.md-post__related-card:hover .md-post__related-title {
+    color: var(--md-accent-fg-color);
+}
+
+.md-post__related-date {
+    font-size: 0.64rem;
+    color: var(--md-default-fg-color--light);
+}
+
+.md-post__related-excerpt {
+    font-size: 0.75rem;
+    color: var(--md-default-fg-color--light);
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    margin: 0;
+}
+
+@media max-width: 30em {
+    .md-post__related-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* 404 page button – matches back-to-top button styling */
 .md-button.md-top-button {
     background-color: var(--md-default-bg-color) !important;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,9 @@ use_directory_urls: false
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - javascripts/extra.js
+
 extra:
   social:
     - icon: fontawesome/brands/linkedin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ theme:
       accent: deep purple
   
   features:
+    - back_to_top
     - content.code.copy
     - content.code.select
     - content.code.annotate

--- a/overrides/404.html
+++ b/overrides/404.html
@@ -6,7 +6,7 @@
     The content you're looking for doesn't exist or has been moved.
   </p>
   <p>
-    <a href="{{ config.site_url }}" class="md-button md-button--primary">
+    <a href="{{ config.site_url }}" class="md-button md-button--primary md-top-button">
       Back to the surface
     </a>
   </p>

--- a/overrides/blog-post.html
+++ b/overrides/blog-post.html
@@ -131,6 +131,50 @@
       {% block content %}
         {% include "partials/content.html" %}
 
+        <!-- Post Navigation -->
+        {% if page.previous_page or page.next_page %}
+        <nav class="md-post__navigation md-typeset">
+          <div class="md-post__nav">
+            {% if page.previous_page %}
+            <div class="md-post__nav--prev">
+              <a href="{{ page.previous_page.url | url }}" class="md-post__nav-link">
+                <div class="md-post__nav-icon">
+                  {% include ".icons/material/arrow-left.svg" %}
+                </div>
+                <div class="md-post__nav-label">
+                  <span class="md-post__nav-direction">Previous Delve</span>
+                  <span class="md-post__nav-title">{{ page.previous_page.title }}</span>
+                  <span class="md-post__nav-date">
+                    <time datetime="{{ page.previous_page.config.date.created }}">
+                      {{ page.previous_page.config.date.created | date }}
+                    </time>
+                  </span>
+                </div>
+              </a>
+            </div>
+            {% endif %}
+            {% if page.next_page %}
+            <div class="md-post__nav--next">
+              <a href="{{ page.next_page.url | url }}" class="md-post__nav-link">
+                <div class="md-post__nav-label">
+                  <span class="md-post__nav-direction">Next Delve</span>
+                  <span class="md-post__nav-title">{{ page.next_page.title }}</span>
+                  <span class="md-post__nav-date">
+                    <time datetime="{{ page.next_page.config.date.created }}">
+                      {{ page.next_page.config.date.created | date }}
+                    </time>
+                  </span>
+                </div>
+                <div class="md-post__nav-icon">
+                  {% include ".icons/material/arrow-right.svg" %}
+                </div>
+              </a>
+            </div>
+            {% endif %}
+          </div>
+        </nav>
+        {% endif %}
+
         <!-- Related Posts -->
         {% if related_posts %}
         <hr>

--- a/overrides/blog-post.html
+++ b/overrides/blog-post.html
@@ -177,29 +177,30 @@
 
         <!-- Related Posts -->
         {% if related_posts %}
-        <hr>
-        <h2 id="related-posts">Related Posts</h2>
-        <div class="related-posts">
-          {% for item in related_posts %}
-          {% set post = item.page %}
-          <div class="related-post">
-            <a href="{{ post.url | url }}" class="related-post__link">
-              <h3 class="related-post__title">{{ post.title }}</h3>
-              <div class="related-post__meta">
-                <time datetime="{{ post.config.date.created }}">
-                  {{ post.config.date.created | date }}
-                </time>
-                {% if post.config.readtime %}
-                · {{ lang.t("readtime.other") | replace("#", post.config.readtime) if post.config.readtime != 1 else lang.t("readtime.one") }}
+        <section class="md-post__related md-typeset">
+          <h2 class="md-post__related-heading">Related Delves</h2>
+          <div class="md-post__related-grid">
+            {% for item in related_posts %}
+            {% set post = item.page %}
+            <div class="md-post__related-card">
+              <a href="{{ post.url | url }}" class="md-post__related-link">
+                <span class="md-post__related-title">{{ post.title }}</span>
+                <span class="md-post__related-date">
+                  <time datetime="{{ post.config.date.created }}">
+                    {{ post.config.date.created | date }}
+                  </time>
+                  {% if post.config.readtime %}
+                  · {{ lang.t("readtime.other") | replace("#", post.config.readtime) if post.config.readtime != 1 else lang.t("readtime.one") }}
+                  {% endif %}
+                </span>
+                {% if item.excerpt %}
+                <p class="md-post__related-excerpt">{{ item.excerpt | truncate(120) }}</p>
                 {% endif %}
-              </div>
-              {% if item.excerpt %}
-              <p class="related-post__excerpt">{{ item.excerpt | truncate(150) }}</p>
-              {% endif %}
-            </a>
+              </a>
+            </div>
+            {% endfor %}
           </div>
-          {% endfor %}
-        </div>
+        </section>
         {% endif %}
       {% endblock %}
     </article>

--- a/overrides/blog-post.html
+++ b/overrides/blog-post.html
@@ -1,6 +1,7 @@
 {%- extends "main.html" %}
 {% import "partials/nav-item.html" as item with context %}
 {% block container %}
+  {% include "partials/top.html" %}
   <div class="md-content md-content--post" data-md-component="content">
     <div class="md-sidebar md-sidebar--post" data-md-component="sidebar" data-md-type="navigation">
       <div class="md-sidebar__scrollwrap">

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -19,6 +19,7 @@
 
 <!-- Page content -->
 {% block container %}
+{% include "partials/top.html" %}
 <div class="md-content" data-md-component="content">
     <div class="md-content__inner">
 

--- a/plugins/related_posts.py
+++ b/plugins/related_posts.py
@@ -91,15 +91,16 @@ class RelatedPostsPlugin(BasePlugin):
             if shared:
                 related.append((len(shared), post))
 
-        # Sort by number of shared tags (descending), then by date (descending)
-        def sort_key(item):
-            count, post = item
-            date_str = ""
+        # Sort by date (descending), then by shared tags (descending)
+        # Python's sort is stable, so the second sort preserves date order for equal counts
+        def date_key(item):
+            post = item[1]
             if hasattr(post, "config") and hasattr(post.config, "date"):
-                date_str = post.config.date.created
-            return (-count, date_str)
+                return post.config.date.created
+            return ""
 
-        related.sort(key=sort_key)
+        related.sort(key=date_key, reverse=True)
+        related.sort(key=lambda item: -item[0])
 
         # Limit to 5 related posts, and attach excerpt description to each
         context["related_posts"] = []


### PR DESCRIPTION
## Changes

### Post Navigation
- Added prev/next post navigation links below blog post content
- Card-style buttons with arrow icons, direction labels ("Previous Delve" / "Next Delve"), title, and date
- Hover transitions to accent color matching site link behavior
- Responsive: two-column grid collapsing to single column on smaller screens

### Reading Progress Bar
- Replaced hardcoded gradient colors with theme CSS variables (`--md-primary-fg-color--light` → `--md-accent-fg-color`)
- Removed separate dark theme rule — adapts automatically to light/dark mode

### 404 Page Button
- Restyled "Back to the Surface" button to match the back-to-top button
- Pill-shaped with gray text on light background, subtle shadow, accent hover

### Related Posts
- Renamed heading to "Related Delves" for consistency
- Card grid layout with matching border/shadow/hover behavior as navigation
- Titles use link color → accent on hover, line-clamped to 2 lines
- Dates and excerpts in subtle gray
- Responsive auto-filling grid