### PR TITLE
feat: add preview-cards and new-post tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ site
 __pycache__
 *.egg-info
 scratch
+card_preview.html

--- a/justfile
+++ b/justfile
@@ -26,3 +26,19 @@ lint-fix:
 clean:
     #!/usr/bin/env bash
     rm -rf site
+
+# Preview generated social cards in the browser
+preview-cards:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -d "site/assets/images/social" ]; then
+        echo "No social cards found. Run 'just doc' first."
+        exit 1
+    fi
+    python3 scripts/generate_card_preview.py
+    xdg-open card_preview.html
+
+# Scaffold a new blog post
+## Usage: just new-post "My Post Title"
+new-post title:
+    python3 scripts/new_post.py "{{title}}"

--- a/scripts/generate_card_preview.py
+++ b/scripts/generate_card_preview.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Generate an HTML page to preview all social cards."""
+
+import glob
+import os
+
+
+def main():
+    social_dir = "site/assets/images/social"
+    cards = []
+
+    # Collect all card images (PNG files)
+    for path in glob.glob(os.path.join(social_dir, "**", "*.png"), recursive=True):
+        # Extract relative path from social dir
+        rel = os.path.relpath(path, social_dir)
+        parts = rel.replace(os.sep, "/").split("/")
+        if len(parts) >= 3:
+            year, month, day = parts[0], parts[1], parts[2]
+            filename = parts[3] if len(parts) > 3 else parts[2]
+            date_str = f"{year}-{month}-{day}"
+        elif len(parts) == 2:
+            year, month = parts[0], parts[1]
+            filename = parts[1]
+            date_str = f"{year}-{month}"
+        else:
+            date_str = "root"
+            filename = parts[0]
+
+        cards.append({
+            "path": f"site/assets/images/social/{rel}",
+            "date": date_str,
+            "filename": filename,
+        })
+
+    # Sort by date descending
+    cards.sort(key=lambda c: c["date"], reverse=True)
+
+    # Generate HTML
+    cards_html = ""
+    for card in cards:
+        cards_html += f"""        <div class="card">
+            <img src="{card['path']}" alt="{card['filename']}">
+            <div class="card-info">
+                <span class="date">{card['date']}</span>
+            </div>
+        </div>
+"""
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Social Cards Preview</title>
+    <style>
+        * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            padding: 2rem;
+        }}
+        h1 {{
+            font-size: 1.5rem;
+            margin-bottom: 0.5rem;
+            color: #ffffff;
+        }}
+        .subtitle {{
+            font-size: 0.85rem;
+            color: #888;
+            margin-bottom: 2rem;
+        }}
+        .grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 1.5rem;
+        }}
+        .card {{
+            background: #16213e;
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid #2a2a4a;
+        }}
+        .card img {{
+            width: 100%;
+            display: block;
+        }}
+        .card-info {{
+            padding: 0.75rem 1rem;
+            font-size: 0.75rem;
+            color: #888;
+        }}
+        .card-info .date {{
+            color: #526cfe;
+            font-weight: 600;
+        }}
+    </style>
+</head>
+<body>
+    <h1>Social Cards Preview</h1>
+    <p class="subtitle">{len(cards)} cards found</p>
+    <div class="grid">
+{cards_html}    </div>
+</body>
+</html>
+"""
+
+    with open("card_preview.html", "w") as f:
+        f.write(html)
+
+    print(f"Generated card_preview.html with {len(cards)} cards")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/new_post.py
+++ b/scripts/new_post.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Scaffold a new blog post with front matter."""
+
+import argparse
+import datetime
+import os
+import re
+import sys
+
+
+def slugify(title):
+    """Convert title to URL-friendly slug."""
+    slug = title.lower()
+    slug = re.sub(r'[^a-z0-9]', '-', slug)
+    slug = re.sub(r'-{2,}', '-', slug)
+    slug = slug.strip('-')
+    return slug
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a new blog post scaffold.")
+    parser.add_argument("title", help="Title of the blog post")
+    parser.add_argument(
+        "--date", "-d",
+        default=datetime.date.today().isoformat(),
+        help="Post date (YYYY-MM-DD, default: today)"
+    )
+    args = parser.parse_args()
+
+    slug = slugify(args.title)
+    filename = f"docs/posts/{args.date}-{slug}.md"
+
+    if os.path.exists(filename):
+        print(f"Error: {filename} already exists.", file=sys.stderr)
+        sys.exit(1)
+
+    content = f"""---
+date: {args.date}
+categories:
+  -
+tags:
+  -
+social:
+  cards_layout_options:
+    title: {args.title}
+---
+
+# TODO: Add title
+
+![Banner](../assets/images/banners/TODO.webp)
+
+> "TODO: Add epigraph quote" - Author
+
+<!-- more -->
+
+"""
+
+    with open(filename, "w") as f:
+        f.write(content)
+
+    print(f"Created: {filename}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two development workflow enhancements to speed up content creation and visual QA.

### `just preview-cards`

Generates a dark-themed HTML grid preview of all social/OG cards from `site/assets/images/social/` and opens it in the default browser. Useful for quickly checking card output without digging through the build directory.

- Adds `scripts/generate_card_preview.py` — collects all PNG files recursively, extracts date info from directory structure, renders a responsive grid
- Adds `card_preview.html` to `.gitignore`

### `just new-post "Title"`

Scaffolds a new blog post file at `docs/posts/{date}-{slug}.md` with:
- Proper front matter (date, categories, tags, social cards layout options)
- Banner placeholder
- Epigraph blockquote
- `<!-- more -->` excerpt marker

- Adds `scripts/new_post.py` — handles slug generation (lowercase, hyphenated, no consecutive dashes), date defaulting to today, and duplicate file detection

### Files

| File | Purpose |
|---|---|
| [justfile](justfile) | Added `preview-cards` and `new-post` recipes |
| [scripts/generate_card_preview.py](scripts/generate_card_preview.py) | Social card HTML preview generation |
| [scripts/new_post.py](scripts/new_post.py) | Blog post scaffolding |
| [.gitignore](.gitignore) | Added `card_preview.html` |

---

Closes enhancement tasks from `scratch/enhancements.md` section 5.
