### PR TITLE
Improve about page and add RSS feed link

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -2,9 +2,31 @@
 
 ![Avatar](assets/images/avatar/avatar.webp)
 
-Welcome to my blog data delver! I'm so glad you found your way here!
-My name is Chase Greco, I'm currently a machine learning engineer with 5+ years of industry experience.
-I love exploring all things machine learning with a particular emphasis on practical application and "making things real".
-I started this blog to document my own "delves" into the labyrinth of Data Science, Machine Learning, and MLOps along with any resulting knowledge I have unearthed.
+Welcome to my blog, data delver! I'm so glad you found your way here.
 
-If you would like to contact me you can do so at chase@datadelver.com
+My name is **Chase Greco**, and I'm a machine learning engineer with **8+ years** of industry experience building and shipping production ML systems. I've been creating software since the '10s, beginning with writing Minecraft plugins, and eventually finding my way into the labyrinth of data science and machine learning.
+
+These days I focus on the intersection of ML and software engineering: taking models out of notebooks and into production, building systems that actually work at scale, and figuring out the messy gaps between what the tutorials show and what enterprises actually need.
+
+## Why This Blog Exists
+
+I started DataDelver to document my own "delves" into the world of Data Science, Machine Learning, and MLOps, along with any knowledge I unearth along the way. My writing leans heavily toward **practical application** and **"making things real"**. If a concept can't survive contact with production, you won't find it here.
+
+Some of the topics I write about most:
+
+- **ML Engineering & MLOps** - productionizing models, microservices architectures, and the tooling that makes it all work
+- **Industry Perspectives** - what it's really like practicing data science and ML engineering in the real world
+- **Hands-on Tutorials** - step-by-step guides for tools and techniques I've found useful
+- **Fun Projects** - Raspberry Pi experiments, local LLM setups, and other side quests
+
+## Get in Touch
+
+If you'd like to connect, you can reach me through any of the following:
+
+|                                        | Link                                                                  |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| :fontawesome-regular-envelope: Email   | [chase@datadelver.com](mailto:chase@datadelver.com)                   |
+| :fontawesome-brands-linkedin: LinkedIn | [linkedin.com/in/chasegreco](https://www.linkedin.com/in/chasegreco/) |
+| :fontawesome-brands-github: GitHub     | [github.com/DataDelver](https://github.com/DataDelver)                |
+
+Thanks for stopping by and happy delving!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,9 @@ markdown_extensions:
   - md_in_html
   - pymdownx.blocks.caption
   - admonition
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 use_directory_urls: false
 
@@ -131,11 +134,14 @@ extra:
     - icon: fontawesome/brands/linkedin
       name: LinkedIn
       link: https://www.linkedin.com/in/chasegreco/
-    - icon: /fontawesome/regular/envelope
+    - icon: fontawesome/regular/envelope
       name: Email
       link: mailto:chase@datadelver.com
     - icon: fontawesome/brands/github
       name: GitHub
       link: https://github.com/DataDelver
+    - icon: fontawesome/solid/square-rss
+      name: RSS Feed
+      link: https://www.datadelver.com/feed_rss_created.xml
 
 copyright: Copyright &copy; 2023 - 2026 Chase Greco


### PR DESCRIPTION
## Changes

### About Page
- Rewrite with updated **8+ years** experience
- Add background story (Minecraft plugins → data science/ML)
- Add focus area description (ML + SWE intersection)
- Add "Why This Blog Exists" section with topic categories
- Add structured contact table with FontAwesome icons
- Keep the delver/delve theme and conversational tone

### Site Config (mkdocs.yml)
- Add `pymdownx.emoji` extension for icon rendering in markdown content
- Add RSS feed link to footer social links
- Fix email icon path (removed leading `/`)
