### PR TITLE
fix(rss): add real name to managingEditor per RSS Advisory Board Best Practices

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: DataDelver
 site_url: https://www.datadelver.com
 site_description: Exploring the labyrinth of Data Science, Machine Learning, and MLOps one delve at a time.
-site_author: chase@datadelver.com
+site_author: chase@datadelver.com (Chase Greco)
 site_logo: assets/images/favicon/pickaxe.webp
 
 repo_name: datadelver.github.io


### PR DESCRIPTION
## Summary

Updates the `site_author` format in `mkdocs.yml` to follow the [RSS Advisory Board's Best Practices Profile](https://www.rssboard.org/rss-profile#element-channel-managingEditor), which recommends the format: `username@hostname.tld (Real Name)`.

## Change

```diff
- site_author: Chase Greco
+ site_author: chase@datadelver.com (Chase Greco)
```

## Result

Both RSS feeds now output the `<managingEditor>` element in the recommended format:

```xml
<managingEditor>chase@datadelver.com (Chase Greco)</managingEditor>
```

This provides both a valid email address for contact and a human-readable name for display purposes.