### PR TITLE
fix(rss): correct match_path and date meta fields

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,9 +81,10 @@ plugins:
   - lazy_images
   - meta
   - rss:
-      match_path: blog/posts/.* 
+      match_path: posts/.* 
       date_from_meta:
-        as_creation: date
+        as_creation: date.created
+        as_update: date.updated
       image: https://www.datadelver.com/assets/images/favicon/pickaxe.png
       categories:
         - categories


### PR DESCRIPTION
## Changes

Fix RSS feed configuration in `mkdocs.yml`:

- **Fix match_path**: Changed from `blog/posts/.*` to `posts/.*` to match actual post URL patterns
- **Fix creation date**: Changed `as_creation` from `date` to `date.created` for proper creation date extraction
- **Add update date**: Added `as_update: date.updated` for proper update date tracking in the RSS feed

## Why

The RSS feed plugin wasn't correctly matching posts and extracting dates due to incorrect path pattern and meta field names.