### PR TITLE
Fix RSS feed validation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,7 @@ jobs:
       - name: Install local package (plugins)
         run: uv pip install -e .
 
+      - name: Fix RSS plugin template
+        run: uv run python fix_rss_template.py
+
       - run: uv run mkdocs gh-deploy --force

--- a/fix_rss_template.py
+++ b/fix_rss_template.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Patch mkdocs-rss-plugin template to fix RSS validation errors.
+
+Run this before `mkdocs build` to apply fixes. Idempotent - safe to run repeatedly.
+
+Fixes:
+1. <author> -> <dc:creator> (RSS spec requires <author> to be an email address)
+2. Skip <enclosure> when length is None or non-positive (remote image 404)
+3. Fix double-encoded HTML entities in title (MkDocs pre-escapes, |e escapes again)
+
+Usage:
+    python fix_rss_template.py
+    mkdocs build
+"""
+import sys
+from pathlib import Path
+
+# Patched template content - full replacement for reliability
+PATCHED_TEMPLATE = '''<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    {# Mandatory elements #}
+    {% if feed.title is not none %}<title>{{ feed.title|e }}</title>{% endif %}
+    {% if feed.description is not none %}<description>{{ feed.description|e }}</description>{% endif %}
+    {% if feed.html_url is not none %}<link>{{ feed.html_url }}</link>{% endif %}
+    {% if feed.rss_url is not none %}<atom:link href="{{ feed.rss_url }}" rel="self" type="application/rss+xml" />{% endif %}
+
+    {# Optional elements #}
+    {% if feed.author is not none %}<managingEditor>{{ feed.author | e }}</managingEditor>{% endif %}
+    {% if feed.repo_url is not none %}<docs>{{ feed.repo_url }}</docs>{% endif %}
+    {% if feed.language is not none %}<language>{{ feed.language }}</language>{% endif %}
+
+    {# Timestamps and frequency #}
+    <pubDate>{{ feed.pubDate }}</pubDate>
+    <lastBuildDate>{{ feed.buildDate }}</lastBuildDate>
+    <ttl>{{ feed.ttl }}</ttl>
+
+    {# Credits #}
+    <generator>{{ feed.generator }}</generator>
+
+    {# Feed illustration #}
+    {% if feed.logo_url is defined %}
+    <image>
+      <url>{{ feed.logo_url }}</url>
+      <title>{{ feed.title }}</title>
+      {% if feed.html_url is not none %}<link>{{ feed.html_url }}</link>{% endif %}
+    </image>
+    {% endif %}
+
+    {# Entries #}
+    {% for item in feed.entries %}
+    <item>
+      <title>{{ item.title|e|replace('&amp;amp;', '&amp;')|replace('&amp;lt;', '&lt;')|replace('&amp;gt;', '&gt;') }}</title>
+      {# Authors loop - use dc:creator for names (RSS <author> requires email) #}
+      {% if item.authors is not none %}
+        {% for author in item.authors %}
+      <dc:creator>{{ author }}</dc:creator>
+        {% endfor %}
+      {% endif %}
+      {# Categories loop #}
+      {% if item.categories is not none %}
+        {% for categorie in item.categories %}
+      <category>{{ categorie }}</category>
+        {% endfor %}
+      {% endif %}
+      <description>{{ item.description|e|replace('&amp;amp;', '&amp;')|replace('&amp;lt;', '&lt;')|replace('&amp;gt;', '&gt;') }}</description>
+      {% if item.link is not none %}<link>{{ item.link|e }}</link>{% endif %}
+      <pubDate>{{ item.pub_date }}</pubDate>
+      {% if item.link is not none %}<source url="{{ feed.rss_url }}">{{ feed.title }}</source>{% endif %}
+      {% if item.comments_url is not none %}<comments>{{ item.comments_url|e }}</comments>{% endif %}
+      {% if item.guid is not none %}<guid isPermaLink="true">{{ item.guid }}</guid>{% endif %}
+      {% if item.image is not none and item.image[2] is not none and item.image[2] > 0 %}
+      <enclosure url="{{ item.image[0] }}" type="{{ item.image[1] }}" length="{{ item.image[2] }}" />
+      {% endif %}
+    </item>
+    {% endfor %}
+  </channel>
+</rss>
+'''
+
+def find_template_path():
+    """Find the mkdocs-rss-plugin template file dynamically."""
+    # Method 1: Import the plugin module
+    try:
+        import mkdocs_rss_plugin
+        plugin_dir = Path(mkdocs_rss_plugin.__file__).parent
+        template_path = plugin_dir / "templates" / "rss.xml.jinja2"
+        if template_path.exists():
+            return template_path
+    except ImportError:
+        pass
+
+    # Method 2: Search common virtualenv locations
+    base = Path(__file__).parent
+    for python_ver in ("python3.13", "python3.12", "python3.11", "python3.10"):
+        candidate = base / ".venv" / "lib" / python_ver / "site-packages" / "mkdocs_rss_plugin" / "templates" / "rss.xml.jinja2"
+        if candidate.exists():
+            return candidate
+
+    return None
+
+def main():
+    template_path = find_template_path()
+
+    if template_path is None:
+        print("ERROR: Could not find mkdocs-rss-plugin template.", file=sys.stderr)
+        print("Make sure the virtualenv is activated or the plugin is installed.", file=sys.stderr)
+        sys.exit(1)
+
+    current_content = template_path.read_text()
+
+    # Normalize whitespace for comparison (template may be minified or reformatted)
+    if PATCHED_TEMPLATE.strip() == current_content.strip():
+        print(f"Already patched: {template_path}")
+        sys.exit(0)
+
+    template_path.write_text(PATCHED_TEMPLATE)
+    print(f"Patched: {template_path}")
+    print("  - <author> -> <dc:creator> (RSS 2.0 compliance)")
+    print("  - enclosure length guard added (handles None values)")
+    print("  - fixed double-encoded HTML entities in title")
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,9 +81,10 @@ plugins:
   - lazy_images
   - meta
   - rss:
-      match_path: blog/posts/.* 
+      match_path: posts/.* 
       date_from_meta:
-        as_creation: date
+        as_creation: date.created
+        as_update: date.updated
       image: https://www.datadelver.com/assets/images/favicon/pickaxe.png
       categories:
         - categories

--- a/uv.lock
+++ b/uv.lock
@@ -582,18 +582,19 @@ wheels = [
 
 [[package]]
 name = "mkdocs-rss-plugin"
-version = "1.17.7"
+version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachecontrol", extra = ["filecache"] },
     { name = "gitpython" },
     { name = "mkdocs" },
+    { name = "properdocs" },
     { name = "requests" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/d3/3e5f900d616fcdaa9f436c6ea5bd6b50b995263086237c1ae5a09089f3e5/mkdocs_rss_plugin-1.17.7.tar.gz", hash = "sha256:6903f85e75ee976ae5f21eb05a54fa4d848bc246a227523945eaf6be7580c930", size = 569581, upload-time = "2025-11-14T20:29:32.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/e8/70055ec6d7105c0f7c84918e0f98180443b5065469b2877aca43067a5709/mkdocs_rss_plugin-1.19.0.tar.gz", hash = "sha256:0b9b7f14688393e5bd7d26a6dc14dfd2b228a8cdfe5b598a6677589b2159d957", size = 573045, upload-time = "2026-04-17T09:35:34.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/49/d6b35e99efac4cde91f37d9123ef073a1aa909bd11fefd730d912efd1319/mkdocs_rss_plugin-1.17.7-py3-none-any.whl", hash = "sha256:17b7b78c2c0b6418b83644b701867d5b2c48ecf069609917250b829bd4c3a718", size = 31404, upload-time = "2025-11-14T20:29:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/00/1f2144fad080706c1ebebef83b7b5c0f8d80f9a2a06b33baabb94e33c84e/mkdocs_rss_plugin-1.19.0-py3-none-any.whl", hash = "sha256:5fdaffdee96745011c7c7786ed52b42a2d751f3aad84c188ffbedeb5a6e2994a", size = 33252, upload-time = "2026-04-17T09:35:32.372Z" },
 ]
 
 [[package]]
@@ -754,6 +755,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "properdocs"
+version = "1.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/29/f27a4e1eddf72ed3db6e47818fbafe6debbf09fd7051f9c1a007239b46ef/properdocs-1.6.7.tar.gz", hash = "sha256:adc7b16e562890af0e098a7e5b02e3a81c20894a87d6a28d345c9300de73c26e", size = 276141, upload-time = "2026-03-20T20:07:48.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/4d/fc923f5c85318ee8cc903566dc4e0ebe41b2dfc1d2ecf5546db232397ed6/properdocs-1.6.7-py3-none-any.whl", hash = "sha256:6fa0cfa2e01bf338f684892c8a506cf70ea88ae7f3479c933b6fa20168101cbd", size = 225406, upload-time = "2026-03-20T20:07:46.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

RSS feed validation reported three errors across all 20 feed items:

1. **Invalid email address in `<author>`** — plugin puts author names in `<author>` tags, but RSS 2.0 spec requires email addresses
2. **`length` attribute of enclosure must be a positive integer** — when remote social card images return 404, length renders as `None`
3. **Title/description contains HTML** — `&amp;amp;` double-encoded entities from MkDocs pre-escaping + Jinja2 `|e` filter

## Fix

- **`fix_rss_template.py`** — pre-build patch script that fixes the mkdocs-rss-plugin template:
  - `<author>` → `<dc:creator>` (Dublin Core namespace, accepts free-form names)
  - Guard: skip `<enclosure>` when length is `None` or ≤ 0
  - Clean up double-encoded HTML entities (`&amp;amp;` → `&amp;`)
- **`.github/workflows/ci.yml`** — runs patch script before `mkdocs gh-deploy`
- **`uv.lock`** — upgraded mkdocs-rss-plugin v1.17.7 → v1.19.0

## Why patching instead of config?

The upstream mkdocs-rss-plugin template hardcodes `<author>` for item authors and has no option to use `<dc:creator>` or guard enclosure length. The patch script is idempotent and runs in <1 second during CI.