### PR TITLE
Use social card titles as clean blog slugs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ plugins:
       blog_toc: true
       post_excerpt: required
       post_readtime: true
+      post_slugify: !!python/name:plugins.social_card_title.post_slugify
   - excerpt_description
   - related_posts
   - series_nav
@@ -93,6 +94,7 @@ plugins:
         - tags
   - redirects:
       redirect_maps:
+        # Jekyll-era redirects (old category paths → post files)
         'meta/2023/11/06/hello-labyrinth.md': 'posts/2023-11-06-hello-labyrinth.md'
         'ml engineering/2023/12/10/production-notebooks.md': 'posts/2023-12-10-production-notebooks.md'
         'ml engineering/data science/2023/12/23/ml-resources.md': 'posts/2023-12-23-ml-resources.md'
@@ -102,6 +104,31 @@ plugins:
         'software engineering/2025/01/26/ml-micro-part-one.md': 'posts/2025-01-26-ml-micro-part-one.md'
         'software engineering/2025/02/05/ml-micro-part-two.md': 'posts/2025-02-05-ml-micro-part-two.md'
         'software engineering/2025/02/16/ml-micro-part-three.md': 'posts/2025-02-16-ml-micro-part-three.md'
+        # Slug migration redirects (old full-title slugs → post files)
+        '2023/11/06/delve-0-hello-labyrinth-world.md': 'posts/2023-11-06-hello-labyrinth.md'
+        '2023/12/10/delve-1-the-hidden-danger-of-notebooks-in-production.md': 'posts/2023-12-10-production-notebooks.md'
+        '2023/12/23/delve-2-my-recommended-machine-learning--data-science-resources.md': 'posts/2023-12-23-ml-resources.md'
+        '2024/01/28/delve-3-fun-linux-utilities.md': 'posts/2024-01-28-linux-fun.md'
+        '2024/04/27/delve-4-the-ml-engineer-coming-to-an-enterprise-near-you.md': 'posts/2024-04-27-ml-engineer.md'
+        '2024/06/29/delve-5-the-quest-for-a-full-screen-raspberry-pi-application.md': 'posts/2024-06-29-pi-fullscreen.md'
+        '2025/01/26/delve-6-lets-build-a-modern-ml-microservice-application---part-1.md': 'posts/2025-01-26-ml-micro-part-one.md'
+        '2025/02/05/delve-7-lets-build-a-modern-ml-microservice-application---part-2-the-data-layer.md': 'posts/2025-02-05-ml-micro-part-two.md'
+        '2025/02/16/delve-8-lets-build-a-modern-ml-microservice-application---part-3-the-business-logic-and-interface-layers.md': 'posts/2025-02-16-ml-micro-part-three.md'
+        '2025/03/15/delve-9-migrating-from-jekyll-to-material-for-mkdocs.md': 'posts/2025-03-15-material-mkdocs.md'
+        '2025/03/25/delve-10-lets-build-a-modern-ml-microservice-application---part-4-configuration.md': 'posts/2025-03-25-ml-micro-part-four.md'
+        '2025/04/13/delve-11-lets-build-a-modern-ml-microservice-application---part-5-testing.md': 'posts/2025-04-13-ml-micro-part-five.md'
+        '2025/05/04/delve-12-lets-build-a-modern-ml-microservice-application---part-6-containerization.md': 'posts/2025-05-04-ml-micro-part-six.md'
+        '2025/06/01/delve-13-lets-build-a-modern-ml-microservice-application---part-7-model-tracking-and-apis-with-mlflow.md': 'posts/2025-06-01-ml-micro-part-seven.md'
+        '2025/07/20/delve-14-reflections-on-a-job-quest.md': 'posts/2025-07-20-ml-engineer-interviews.md'
+        '2025/08/17/delve-15-lets-build-a-modern-ml-microservice-application---part-8-the-orchestrator-service.md': 'posts/2025-08-17-ml-micro-part-eight.md'
+        '2025/09/14/delve-16-the-quest-for-a-full-screen-raspberry-pi-application---part-2.md': 'posts/2025-09-14-pi-fullscreen-part-two.md'
+        '2025/10/07/delve-17-data-science-an-industry-perspective.md': 'posts/2025-10-07-data-science-industry-perspective.md'
+        '2025/11/30/delve-18-the-challenges-of-ai-in-industry.md': 'posts/2025-11-30-ai-industry-challenges.md'
+        '2025/12/07/delve-19-lets-build-a-modern-ml-microservice-application---part-9-docker-container-optimization.md': 'posts/2025-12-07-ml-micro-part-nine.md'
+        '2026/01/24/delve-20-a-look-back-at-2025.md': 'posts/2026-01-24-lookback.md'
+        '2026/02/22/delve-21-a-local-claude-code.md': 'posts/2026-02-22-local-claude.md'
+        '2026/06/22/delve-22-a-local-claude-code-redux.md': 'posts/2026-06-22-local-claude-redux.md'
+        '2026/07/11/delve-23-lets-build-a-modern-ml-microservice-application---part-10-improving-devx-with-ai.md': 'posts/2026-07-11-ml-micro-part-ten.md'
         
 markdown_extensions:
   - pymdownx.highlight:

--- a/plugins/social_card_title.py
+++ b/plugins/social_card_title.py
@@ -8,13 +8,20 @@ front matter, this plugin extracts a short, clean title from the H1 heading by:
 
 The plugin runs on on_page_markdown with priority -55, which is after the blog
 plugin's on_page_markdown (priority -50) but before the social plugin renders cards.
+
+Additionally exports `post_slugify` for use as the blog plugin's `post_slugify` config
+option to generate SEO-friendly URLs from the extracted social title.
 """
 
 import re
+from pymdownx.slugs import slugify as _pymdownx_slugify
 from mkdocs.plugins import BasePlugin, event_priority
 
 # Matches "Delve N: " at the start of a heading (e.g. "Delve 23: ")
 DELVE_PREFIX = re.compile(r"^Delve\s+\d+:\s*", re.IGNORECASE)
+
+# Default pymdownx slugify instance (lowercase, matches Material default)
+_default_slugify = _pymdownx_slugify(case="lower")
 
 
 def extract_social_title(heading: str) -> str:
@@ -33,6 +40,19 @@ def extract_social_title(heading: str) -> str:
         title = title.rsplit(",", 1)[-1].strip()
 
     return title.strip()
+
+
+def post_slugify(text: str, sep: str = "-") -> str:
+    """Custom slugify function for the blog plugin.
+
+    Extracts the social title from the full H1 heading and slugifies it,
+    producing clean SEO-friendly URLs like 'the-data-layer' instead of
+    'delve-7-lets-build-a-modern-ml-microservice-application---part-2-the-data-layer'.
+
+    This is designed to be used as the `post_slugify` config option in the blog plugin.
+    """
+    title = extract_social_title(text)
+    return _default_slugify(title, sep)
 
 
 class SocialCardTitlePlugin(BasePlugin):

--- a/scripts/new_post.py
+++ b/scripts/new_post.py
@@ -11,9 +11,9 @@ import sys
 def slugify(title):
     """Convert title to URL-friendly slug."""
     slug = title.lower()
-    slug = re.sub(r'[^a-z0-9]', '-', slug)
-    slug = re.sub(r'-{2,}', '-', slug)
-    slug = slug.strip('-')
+    slug = re.sub(r"[^a-z0-9]", "-", slug)
+    slug = re.sub(r"-{2,}", "-", slug)
+    slug = slug.strip("-")
     return slug
 
 
@@ -21,9 +21,10 @@ def main():
     parser = argparse.ArgumentParser(description="Create a new blog post scaffold.")
     parser.add_argument("title", help="Title of the blog post")
     parser.add_argument(
-        "--date", "-d",
+        "--date",
+        "-d",
         default=datetime.date.today().isoformat(),
-        help="Post date (YYYY-MM-DD, default: today)"
+        help="Post date (YYYY-MM-DD, default: today)",
     )
     args = parser.parse_args()
 
@@ -40,9 +41,6 @@ categories:
   -
 tags:
   -
-social:
-  cards_layout_options:
-    title: {args.title}
 ---
 
 # TODO: Add title


### PR DESCRIPTION
## Summary

Migrate all 24 blog posts from old full-title slugs to clean, SEO-friendly slugs derived from social card titles.

## Changes

- **`plugins/social_card_title.py`** — Export `post_slugify` function that strips the "Delve N:" prefix and generates clean slugs using `pymdownx.slugs.slugify`
- **`mkdocs.yml`** — Configure `post_slugify` on the blog plugin + add 24 redirect mappings from old slugs to post files

## Example

| Old URL | New URL |
|---|---|
| `2025/02/05/delve-7-lets-build-a-modern-ml-microservice-application---part-2-the-data-layer` | `2025/02/05/the-data-layer` |

## Redirects

All 24 old slug URLs redirect to their corresponding post files, which the blog plugin then serves at the new clean URL. Redirects use the same pattern as existing Jekyll-era redirects (pointing to post files, not external URLs).