### PR TITLE
fix: add dark background to favicon for Google search visibility

### DIFF
--- a/docs/assets/images/favicon/pickaxe-bg.png
+++ b/docs/assets/images/favicon/pickaxe-bg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:652056b8ecab5038899314284d062c5d95342e7b00ab707837a1effa70bd21a2
+size 5839

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ theme:
     logo: material/pickaxe
     admonition:
       claude: simple/claude
-  favicon: assets/images/favicon/pickaxe.webp
+  favicon: assets/images/favicon/pickaxe-dark.png
   palette:
 
     # Palette toggle for automatic mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ theme:
     logo: material/pickaxe
     admonition:
       claude: simple/claude
-  favicon: assets/images/favicon/pickaxe-dark.png
+  favicon: assets/images/favicon/pickaxe-bg.png
   palette:
 
     # Palette toggle for automatic mode


### PR DESCRIPTION
## Problem

Google displays a white circle icon for the site in search results. The root cause:

- The favicon is a **white pickaxe on transparent background**
- Google displays favicons on a **white background**
- White on white = invisible → Google shows a generic white circle

## Fix

Created `pickaxe-bg.png` — white pickaxe on a dark slate background — so the icon is visible on any background while keeping the white pickaxe aesthetic.

## After merge

- Verify `https://www.datadelver.com/assets/images/favicon/pickaxe-bg.png` loads
- Request re-indexing in [Google Search Console](https://search.google.com/search-console)
- Icon update in search results may take a few days