### PR TITLE
chore: update mkdocs-rss-plugin fork to latest commit with tests

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -582,8 +582,8 @@ wheels = [
 
 [[package]]
 name = "mkdocs-rss-plugin"
-version = "1.19.1.dev19"
-source = { git = "https://github.com/Zerthick/mkdocs-rss-plugin.git?rev=fix%2Frss-validation-errors#100f2768060ae6963086b79f8480684fd1a7bea0" }
+version = "1.19.1.dev20"
+source = { git = "https://github.com/Zerthick/mkdocs-rss-plugin.git?rev=fix%2Frss-validation-errors#4b1c11cbdd7a207ea483636ed31f09964a203014" }
 dependencies = [
     { name = "cachecontrol", extra = ["filecache"] },
     { name = "gitpython" },


### PR DESCRIPTION
## Summary

Updates the forked mkdocs-rss-plugin reference to the latest commit, which includes an improved approach for the double-encoding fix and a test suite.

Upstream PR: [Guts/mkdocs-rss-plugin#451](https://github.com/Guts/mkdocs-rss-plugin/pull/451)

### What changed in the fork

- **Double-encoding fix moved to Python** — Instead of `replace()` filters in the Jinja template, now uses `html_module.unescape()` in plugin.py before passing data to the template. Jinja's `|e` then does a single correct escape.
- **Test suite added** — 3 new tests in `tests/test_rss_validation.py` covering all RSS validation fixes, plus a fixture with special characters (`& < >`). All 36 tests pass.

This is a follow-up to #73 which initially switched to the fork.