### PR TITLE
chore: update mkdocs-rss-plugin fork with XSL HTML preview author fix

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -582,8 +582,8 @@ wheels = [
 
 [[package]]
 name = "mkdocs-rss-plugin"
-version = "1.19.1.dev20"
-source = { git = "https://github.com/Zerthick/mkdocs-rss-plugin.git?rev=fix%2Frss-validation-errors#4b1c11cbdd7a207ea483636ed31f09964a203014" }
+version = "1.19.1.dev23"
+source = { git = "https://github.com/Zerthick/mkdocs-rss-plugin.git?rev=fix%2Frss-validation-errors#0d7068ea99268dc3bf0bfb8ce5e68e4d5ab35f4b" }
 dependencies = [
     { name = "cachecontrol", extra = ["filecache"] },
     { name = "gitpython" },


### PR DESCRIPTION
## Summary

Updates the forked mkdocs-rss-plugin reference to include a fix for the HTML preview page.

Upstream PR: [Guts/mkdocs-rss-plugin#451](https://github.com/Guts/mkdocs-rss-plugin/pull/451)

### What changed

Switching `<author>` → `<dc:creator>` in the RSS template broke author display in the XSL HTML preview, since the XSL was still reading `<author>`. This update:

- Item authors: XSL now reads `<dc:creator>` instead of `<author>`
- Channel author: XSL now reads `<managingEditor>` instead of `<author>`

This is a follow-up to #73 and #74.