### PR TITLE
Add share links (X, LinkedIn, copy-link) to blog posts

### DIFF
--- a/docs/javascripts/extra.js
+++ b/docs/javascripts/extra.js
@@ -10,3 +10,43 @@
   window.addEventListener("scroll", updateProgress, { passive: true });
   updateProgress();
 })();
+
+/* Share Link Copy */
+(function() {
+  const button = document.querySelector(".md-post__share-copy");
+  if (!button) return;
+
+  function showCopied() {
+    const original = button.innerHTML;
+    button.classList.add("copied");
+    button.innerHTML = "Copied!";
+    setTimeout(function() {
+      button.classList.remove("copied");
+      button.innerHTML = original;
+    }, 2000);
+  }
+
+  function fallbackCopy(text) {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textarea);
+  }
+
+  button.addEventListener("click", function() {
+    const url = button.dataset.shareUrl;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(showCopied, function() {
+        fallbackCopy(url);
+        showCopied();
+      });
+    } else {
+      fallbackCopy(url);
+      showCopied();
+    }
+  });
+})();

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -220,6 +220,81 @@ body::after {
     }
 }
 
+/* Share Links */
+.md-post__share {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin: 3.2rem 0 0;
+}
+
+.md-post__share-label {
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--md-default-fg-color--light);
+}
+
+.md-post__share-buttons {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.md-post__share-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.4rem;
+    height: 2.4rem;
+    padding: 0;
+    border-radius: 0.4rem;
+    border: 0.05rem solid var(--md-default-bg-color--lightest);
+    color: var(--md-default-fg-color--light);
+    background: none;
+    cursor: pointer;
+    text-decoration: none;
+    transition: border-color 0.25s, color 0.25s, box-shadow 0.25s;
+}
+
+.md-post__share-btn svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    fill: currentColor;
+    transition: transform 0.25s;
+}
+
+.md-post__share-btn:hover {
+    border-color: var(--md-accent-fg-color);
+    color: var(--md-accent-fg-color);
+    box-shadow: 0 0.0625rem 0.125rem -0.0625rem var(--md-default-fg-color--lighter-03),
+                0 0.25rem 0.5rem -0.125rem var(--md-default-fg-color--lighter-06);
+}
+
+.md-post__share-btn:hover svg {
+    transform: scale(1.1);
+}
+
+/* "Copied!" feedback state — grows to fit the label */
+.md-post__share-copy.copied {
+    width: auto;
+    padding: 0 0.8rem;
+    gap: 0.4rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    border-color: var(--md-accent-fg-color);
+    color: var(--md-accent-fg-color);
+}
+
+@media max-width: 30em {
+    .md-post__share {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
 /* 404 page button – matches back-to-top button styling */
 .md-button.md-top-button {
     background-color: var(--md-default-bg-color) !important;

--- a/overrides/blog-post.html
+++ b/overrides/blog-post.html
@@ -159,6 +159,11 @@
       {% block content %}
         {% include "partials/content.html" %}
 
+        <!-- Share Links -->
+        {% if page.meta.share | default(true) %}
+        {% include "partials/share.html" %}
+        {% endif %}
+
         <!-- Post Navigation -->
         {% if page.previous_page or page.next_page %}
         <nav class="md-post__navigation md-typeset">

--- a/overrides/partials/share.html
+++ b/overrides/partials/share.html
@@ -1,0 +1,23 @@
+{#- Share links: X, LinkedIn, copy-link #}
+{% set share_url = page.canonical_url | urlencode %}
+{% set share_text = page.title | urlencode %}
+<div class="md-post__share">
+  <span class="md-post__share-label">Share this delve</span>
+  <div class="md-post__share-buttons">
+    <a
+      href="https://twitter.com/intent/tweet?url={{ share_url }}&text={{ share_text }}"
+      class="md-post__share-btn" target="_blank" rel="noopener" aria-label="Share on X">
+      {% include ".icons/fontawesome/brands/x-twitter.svg" %}
+    </a>
+    <a
+      href="https://www.linkedin.com/sharing/share-offsite/?url={{ share_url }}"
+      class="md-post__share-btn" target="_blank" rel="noopener" aria-label="Share on LinkedIn">
+      {% include ".icons/fontawesome/brands/linkedin-in.svg" %}
+    </a>
+    <button
+      class="md-post__share-btn md-post__share-copy" type="button"
+      data-share-url="{{ page.canonical_url }}" aria-label="Copy link to post">
+      {% include ".icons/material/content-copy.svg" %}
+    </button>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Adds a compact "Share this delve" row at the end of every blog post, matching the existing \`.md-post__*\` design language and working in both light and dark palettes.

- **X** — intent link with the post title pre-filled as text
- **LinkedIn** — share-offsite link
- **Copy link** — clipboard API with execCommand fallback, brief "Copied!" feedback state

## Details

- New [overrides/partials/share.html](overrides/partials/share.html), included from [overrides/blog-post.html](overrides/blog-post.html) after the post content — posts only, never on home/about/series/tags/404.
- All share URLs derive from \`page.canonical_url\` (absolute, respects \`site_url\` and date-based slugs); URL and title pass through \`| urlencode\` (titles contain colons/apostrophes).
- Per-post opt-out via \`share: false\` front matter.
- Icons are theme-bundled (fontawesome brands for X/LinkedIn, material content-copy); sizing and colors via existing CSS custom properties.
- Styles appended to [extra.css](docs/stylesheets/extra.css), copy-button IIFE appended to [extra.js](docs/javascripts/extra.js) — both already registered in mkdocs.yml.

## Verification

- \`just doc\` builds cleanly; share block renders on posts with correct production URLs in all three targets (verified on Delve 23, whose title has both a colon and an apostrophe).
- Share row absent from non-post pages.
- No new dependencies; no mkdocs.yml changes.